### PR TITLE
Support both annotation JSON string and file path

### DIFF
--- a/android/src/main/java/com/alpha0010/pdf/PdfView.kt
+++ b/android/src/main/java/com/alpha0010/pdf/PdfView.kt
@@ -43,7 +43,7 @@ class PdfView(context: Context, private val pdfMutex: Lock) : View(context) {
     mBitmap = Bitmap.createBitmap(1, 1, Bitmap.Config.ARGB_8888)
   }
 
-  fun setAnnotation(source: String) {
+  fun setAnnotation(source: String, file: Boolean = false) {
     if (source.isEmpty()) {
       if (mAnnotation.isNotEmpty()) {
         mAnnotation = emptyList()
@@ -53,7 +53,11 @@ class PdfView(context: Context, private val pdfMutex: Lock) : View(context) {
     }
 
     try {
-      mAnnotation = Json.decodeFromString(File(source).readText())
+      if (file) {
+        mAnnotation = Json.decodeFromString(File(source).readText())
+      } else {
+        mAnnotation = Json.decodeFromString(source);
+      }
       mDirty = true
     } catch (e: Exception) {
       onError("Failed to load annotation from '$source'. ${e.message}")

--- a/android/src/main/java/com/alpha0010/pdf/PdfViewManager.kt
+++ b/android/src/main/java/com/alpha0010/pdf/PdfViewManager.kt
@@ -41,13 +41,13 @@ class PdfViewManager(private val pdfMutex: Lock) : BaseViewManager<PdfView, PdfV
   /**
    * Set annotation from a PAS v1 JSON string
    */
-  @ReactProp(name = "annotation")
+  @ReactProp(name = "annotationStr")
   fun setAnnotation(view: PdfView, source: String?) = view.setAnnotation(source ?: "")
 
   /**
    * Set annotation from file containing a PAS v1 JSON string
    */
-  @ReactProp(name = "annotationPath")
+  @ReactProp(name = "annotation")
   fun setAnnotationWithPath(view: PdfView, source: String?) = view.setAnnotation(source ?: "", true)
 
   /**

--- a/android/src/main/java/com/alpha0010/pdf/PdfViewManager.kt
+++ b/android/src/main/java/com/alpha0010/pdf/PdfViewManager.kt
@@ -38,8 +38,17 @@ class PdfViewManager(private val pdfMutex: Lock) : BaseViewManager<PdfView, PdfV
     view.renderPdf()
   }
 
+  /**
+   * Set annotation from a PAS v1 JSON string
+   */
   @ReactProp(name = "annotation")
   fun setAnnotation(view: PdfView, source: String?) = view.setAnnotation(source ?: "")
+
+  /**
+   * Set annotation from file containing a PAS v1 JSON string
+   */
+  @ReactProp(name = "annotationPath")
+  fun setAnnotationWithPath(view: PdfView, source: String?) = view.setAnnotation(source ?: "", true)
 
   /**
    * Page (0-indexed) of document to display.

--- a/ios/PdfView.swift
+++ b/ios/PdfView.swift
@@ -5,6 +5,7 @@ enum ResizeMode: String {
 
 class PdfView: UIView {
     @objc var annotation = "" { didSet { loadAnnotation() } }
+    @objc var annotationPath = "" { didSet { loadAnnotation(file: true) } }
     @objc var page: NSNumber = 0 { didSet { renderPdf() } }
     @objc var resizeMode = ResizeMode.CONTAIN.rawValue { didSet { validateResizeMode() } }
     @objc var source = "" { didSet { renderPdf() } }
@@ -23,8 +24,8 @@ class PdfView: UIView {
         super.layoutSubviews()
     }
 
-    private func loadAnnotation() {
-        guard !annotation.isEmpty else {
+    private func loadAnnotation(file: Bool = false) {
+        guard !annotation.isEmpty || !annotationPath.isEmpty else {
             if !annotationData.isEmpty {
                 annotationData.removeAll()
                 renderPdf()
@@ -34,7 +35,13 @@ class PdfView: UIView {
 
         let decoder = JSONDecoder()
         do {
-            let data = try Data(contentsOf: URL(fileURLWithPath: annotation))
+            var data:Data;
+            if (file) {
+                data = try Data(contentsOf: URL(fileURLWithPath: annotationPath))
+            }
+            else {
+                data = annotation.data(using: .utf8)!;
+            }
             annotationData = try decoder.decode([AnnotationPage].self, from: data)
         } catch {
             dispatchOnError(

--- a/ios/PdfView.swift
+++ b/ios/PdfView.swift
@@ -4,8 +4,8 @@ enum ResizeMode: String {
 }
 
 class PdfView: UIView {
-    @objc var annotation = "" { didSet { loadAnnotation() } }
-    @objc var annotationPath = "" { didSet { loadAnnotation(file: true) } }
+    @objc var annotationStr = "" { didSet { loadAnnotation() } }
+    @objc var annotation = "" { didSet { loadAnnotation(file: true) } }
     @objc var page: NSNumber = 0 { didSet { renderPdf() } }
     @objc var resizeMode = ResizeMode.CONTAIN.rawValue { didSet { validateResizeMode() } }
     @objc var source = "" { didSet { renderPdf() } }
@@ -25,7 +25,7 @@ class PdfView: UIView {
     }
 
     private func loadAnnotation(file: Bool = false) {
-        guard !annotation.isEmpty || !annotationPath.isEmpty else {
+        guard !annotation.isEmpty || !annotationStr.isEmpty else {
             if !annotationData.isEmpty {
                 annotationData.removeAll()
                 renderPdf()
@@ -37,10 +37,10 @@ class PdfView: UIView {
         do {
             var data:Data;
             if (file) {
-                data = try Data(contentsOf: URL(fileURLWithPath: annotationPath))
+                data = try Data(contentsOf: URL(fileURLWithPath: annotation))
             }
             else {
-                data = annotation.data(using: .utf8)!;
+                data = annotationStr.data(using: .utf8)!;
             }
             annotationData = try decoder.decode([AnnotationPage].self, from: data)
         } catch {

--- a/ios/PdfViewManager.m
+++ b/ios/PdfViewManager.m
@@ -3,7 +3,7 @@
 @interface RCT_EXTERN_REMAP_MODULE(RNPdfView, PdfViewManager, RCTViewManager)
 
 RCT_EXPORT_VIEW_PROPERTY(annotation, NSString)
-RCT_EXPORT_VIEW_PROPERTY(annotationPath, NSString)
+RCT_EXPORT_VIEW_PROPERTY(annotationStr, NSString)
 RCT_EXPORT_VIEW_PROPERTY(page, NSNumber)
 RCT_EXPORT_VIEW_PROPERTY(resizeMode, NSString)
 RCT_EXPORT_VIEW_PROPERTY(source, NSString)

--- a/ios/PdfViewManager.m
+++ b/ios/PdfViewManager.m
@@ -3,6 +3,7 @@
 @interface RCT_EXTERN_REMAP_MODULE(RNPdfView, PdfViewManager, RCTViewManager)
 
 RCT_EXPORT_VIEW_PROPERTY(annotation, NSString)
+RCT_EXPORT_VIEW_PROPERTY(annotationPath, NSString)
 RCT_EXPORT_VIEW_PROPERTY(page, NSNumber)
 RCT_EXPORT_VIEW_PROPERTY(resizeMode, NSString)
 RCT_EXPORT_VIEW_PROPERTY(source, NSString)

--- a/src/Pdf.tsx
+++ b/src/Pdf.tsx
@@ -106,9 +106,14 @@ type BaseListProps = {
 
 type PdfProps = BaseListProps & {
   /**
-   * Path to annotation data.
+   * PAS v1 annotation JSON string.
    */
   annotation?: string;
+
+  /**
+   * Path to annotation data.
+   */
+  annotationPath?: string;
 
   /**
    * Callback to handle errors.
@@ -314,6 +319,7 @@ export const Pdf = forwardRef((props: PdfProps, ref: React.Ref<PdfRef>) => {
         <View>
           <PdfView
             annotation={props.annotation}
+            annotationPath={props.annotationPath}
             page={index}
             source={source}
             style={styles.page}
@@ -321,7 +327,7 @@ export const Pdf = forwardRef((props: PdfProps, ref: React.Ref<PdfRef>) => {
         </View>
       </View>
     ),
-    [maxPageHeight, props.annotation, source]
+    [maxPageHeight, props.annotation, props.annotationPath, source]
   );
 
   return (

--- a/src/Pdf.tsx
+++ b/src/Pdf.tsx
@@ -108,12 +108,12 @@ type PdfProps = BaseListProps & {
   /**
    * PAS v1 annotation JSON string.
    */
-  annotation?: string;
+  annotationStr?: string;
 
   /**
    * Path to annotation data.
    */
-  annotationPath?: string;
+  annotation?: string;
 
   /**
    * Callback to handle errors.
@@ -319,7 +319,7 @@ export const Pdf = forwardRef((props: PdfProps, ref: React.Ref<PdfRef>) => {
         <View>
           <PdfView
             annotation={props.annotation}
-            annotationPath={props.annotationPath}
+            annotationStr={props.annotationStr}
             page={index}
             source={source}
             style={styles.page}
@@ -327,7 +327,7 @@ export const Pdf = forwardRef((props: PdfProps, ref: React.Ref<PdfRef>) => {
         </View>
       </View>
     ),
-    [maxPageHeight, props.annotation, props.annotationPath, source]
+    [maxPageHeight, props.annotation, props.annotationStr, source]
   );
 
   return (

--- a/src/PdfView.tsx
+++ b/src/PdfView.tsx
@@ -15,7 +15,7 @@ export type ResizeMode = 'contain' | 'fitWidth';
 
 type PdfViewNativeProps = {
   annotation?: string;
-  annotationPath?: string;
+  annotationStr?: string;
   onLayout?: (event: LayoutChangeEvent) => void;
   onPdfError: (event: NativeSyntheticEvent<ErrorEvent>) => void;
   onPdfLoadComplete: (event: NativeSyntheticEvent<LoadCompleteEvent>) => void;
@@ -29,12 +29,12 @@ export type PdfViewProps = {
   /**
    * PAS v1 annotation JSON string.
    */
-  annotation?: string;
+  annotationStr?: string;
 
   /**
    * Path to annotation data.
    */
-  annotationPath?: string;
+  annotation?: string;
   /**
    * Callback to handle errors.
    */
@@ -110,8 +110,8 @@ export function PdfView(props: PdfViewProps) {
 
   return (
     <PdfViewNative
-      annotation={props.annotation}
-      annotationPath={asPath(props.annotationPath)}
+      annotation={asPath(props.annotation)}
+      annotationStr={props.annotationStr}
       onLayout={onLayout}
       onPdfError={onPdfError}
       onPdfLoadComplete={onPdfLoadComplete}

--- a/src/PdfView.tsx
+++ b/src/PdfView.tsx
@@ -15,6 +15,7 @@ export type ResizeMode = 'contain' | 'fitWidth';
 
 type PdfViewNativeProps = {
   annotation?: string;
+  annotationPath?: string;
   onLayout?: (event: LayoutChangeEvent) => void;
   onPdfError: (event: NativeSyntheticEvent<ErrorEvent>) => void;
   onPdfLoadComplete: (event: NativeSyntheticEvent<LoadCompleteEvent>) => void;
@@ -26,10 +27,14 @@ type PdfViewNativeProps = {
 
 type PdfViewProps = {
   /**
-   * Path to annotation data.
+   * PAS v1 annotation JSON string.
    */
   annotation?: string;
 
+  /**
+   * Path to annotation data.
+   */
+  annotationPath?: string;
   /**
    * Callback to handle errors.
    */
@@ -105,7 +110,8 @@ export function PdfView(props: PdfViewProps) {
 
   return (
     <PdfViewNative
-      annotation={asPath(props.annotation)}
+      annotation={props.annotation}
+      annotationPath={asPath(props.annotationPath)}
       onLayout={onLayout}
       onPdfError={onPdfError}
       onPdfLoadComplete={onPdfLoadComplete}


### PR DESCRIPTION
Having only the option to pass the annotation file is quite inconvenient and you can't really have dynamic content. This PR solves this issue by allowing PAS v1 JSON strings directly from the JS side.